### PR TITLE
BUGFIX: Fix key of replaced package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-curl": "*"
     },
     "replace": {
-        "portachtzig/neos-piwik": "self.version"
+        "portachtzig/neos-piwik": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-curl": "*"
     },
     "replace": {
-        "portachtzig/neos-matomo": "self.version"
+        "portachtzig/neos-piwik": "self.version"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The package `portachtzig/neos-matomo` does not exist, it is `portachtzig/neos-piwik`…