### PR TITLE
FEATURE: Allow setting up multiple site ids

### DIFF
--- a/Classes/Controller/Module/MatomoController.php
+++ b/Classes/Controller/Module/MatomoController.php
@@ -36,9 +36,34 @@ class MatomoController extends AbstractModuleController
         $matomoHost = [
             'ip' => $this->reportingService->callAPI('API.getIpFromHeader', [], false),
             'version' => $this->reportingService->callAPI('API.getMatomoVersion', [], false),
-            'site' => $this->reportingService->callAPI('SitesManager.getSiteFromId', [], false),
             'headerLogo' => $this->reportingService->callAPI('API.getHeaderLogoUrl', [], false),
         ];
-        $this->view->assign('matomoHost', $matomoHost);
+
+        if (is_array($this->settings['token_auth'])) {
+            $tokens = $this->settings['token_auth'];
+        } else {
+            $tokens = ['*' => $this->settings['token_auth']];
+        }
+
+        $sites = [];
+        if (is_array($this->settings['idSite'])) {
+            foreach ($this->settings['idSite'] as $sitename => $siteId) {
+                $sites[$sitename] = [
+                    'id' => $siteId,
+                    'matomoName' => $this->reportingService->callAPI('SitesManager.getSiteFromId', [], false, $sitename)
+                ];
+            }
+        } else {
+            $sites = ['*' => [
+                'id' => $this->settings['idSite'],
+                'matomoName' => $this->reportingService->callAPI('SitesManager.getSiteFromId', [], false)
+            ]];
+        }
+
+        $this->view->assignMultiple([
+            'matomoHost' => $matomoHost,
+            'tokens' => $tokens,
+            'sites' => $sites,
+        ]);
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -151,30 +151,21 @@ array.
 
 ### Multi site compatibility
 
-You can override the site id (and the other settings) via fusion like this:
+The Matomo site id and token in the `Settings.yaml` can also be defined as array and this way you can configure as many sites 
+as you want. The plugin will then check for the current sites nodename in this array.
+If no matching site is found, the first entry will be used.
 
-    prototype(Flowpack.Neos.Matomo:TrackingCode) {
-        idSite = Neos.Fusion:Case {
-            myOtherSite {
-                condition = ${site == 'myOtherSite'}
-                renderer = 2
-            }
-    
-            myDefaultSite {
-                condition = ${true}
-                renderer = 1
-            }
-        }
-    }
-    
-Or read it from a sites property like this:
+See this example with one token but several sites:
 
-    prototype(Flowpack.Neos.Matomo:TrackingCode) {
-        idSite = ${q(site).property('trackingId') ? q(site).property('trackingId') : this.settings.idSite}
-    }
-    
-Then you even have a fallback to your settings if the field is left empty. 
-This is useful when having several microsites which are managed from the backend.
+    Flowpack:
+      Neos:
+        Matomo:
+          host: tracking.example.org
+          token_auth: 12345678910
+          idSite:
+            myfirstsite: 1
+            mysecondsite: 2
+            mythirdsite: 2
 
 ## License
 

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
@@ -7,6 +7,7 @@ prototype(Flowpack.Neos.Matomo:TrackingCode) < prototype(Neos.Fusion:Template) {
     protocol = ${this.settings.protocol}
     host = ${this.settings.host}
     idSite = ${this.settings.idSite}
+    idSite.@process.multiSite = ${Type.isArray(value) ? value[site.name] || Array.first(value) : value}
 
     // Show tracking code only in live workspace and if all necessary parameters are set
     @if {

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<title><f:render section="Title" /></title>
-	</head>
-	<body>
-		<f:flashMessages class="flashmessages" />
+    <head>
+        <meta charset="utf-8">
+        <title>
+            <f:render section="Title"/>
+        </title>
+    </head>
+<body>
+    <f:flashMessages class="flashmessages"/>
 
-		<h1><f:render section="Title" /></h1>
-		<f:render section="Content" />
-	</body>
+    <h1>
+        <f:render section="Title"/>
+    </h1>
+    <f:render section="Content"/>
+</body>
 </html>

--- a/Resources/Private/Templates/Module/Matomo/Index.html
+++ b/Resources/Private/Templates/Module/Matomo/Index.html
@@ -7,86 +7,114 @@
 <f:section name="Content">
     <br>
     <div class="neos-row-fluid">
-        <div class="neos-span6">
-            <h2>Configuration</h2>
-            <br>
+        <div class="neos-span8">
             <div class="neos-control-group">
-                <strong>Host:</strong>
-                {settings.host}
+                <h2>Matomo Host Information</h2>
+                <table class="neos-table">
+                    <tr>
+                        <td>Host</td>
+                        <td>{settings.host}</td>
+                    </tr>
+                    <tr>
+                        <td>Protocol</td>
+                        <td>
+                            {settings.protocol}
+                            <span data-toggle="modal" class="neos-inline neos-button neos-button-small"
+                                  href="#protocol-modal">?</span>
+
+                            <div class="neos-hide" id="protocol-modal">
+                                <div class="neos-modal">
+                                    <div class="neos-modal-header">
+                                        <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                        <div class="neos-header">Warning</div>
+                                    </div>
+                                    <div class="neos-subheader">
+                                        <p>
+                                            Be aware that using <b>HTTP</b> for communication with your Matomo host
+                                            <b>{settings.host}</b> will result in your super user's auth_token being transmitted as an
+                                            unencrypted URL parameter!
+                                            <br>
+                                            <br>
+                                        </p>
+                                    </div>
+                                    <div class="neos-modal-footer">
+                                        <a href="#" class="neos-button" data-dismiss="modal">OK</a>
+                                    </div>
+                                </div>
+                                <div class="neos-modal-backdrop neos-in"></div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>IP Address</td>
+                        <td>
+                            <f:if condition="{matomoHost.ip.value}">
+                                <f:then>
+                                    {matomoHost.ip.value} <i class="icon icon-check-circle-o"></i>
+                                </f:then>
+                                <f:else>
+                                    <i>Could not retrieve IP</i> <i class="icon icon-exclamation-triangle"></i>
+                                </f:else>
+                            </f:if>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version</td>
+                        <td>
+                            <f:if condition="{matomoHost.version.value}">
+                                <f:then>
+                                    {matomoHost.version.value} <i class="icon icon-check-circle-o"></i>
+                                </f:then>
+                                <f:else>
+                                    <i>Could not retrieve version</i> <i class="icon icon-exclamation-triangle"></i>
+                                </f:else>
+                            </f:if>
+                        </td>
+                    </tr>
+                </table>
             </div>
 
             <div class="neos-control-group">
-                <strong>Protocol:</strong>
-                {settings.protocol}
-                <span data-toggle="modal" class="neos-inline neos-button neos-button-small"
-                      href="#protocol-modal">?</span>
-            </div>
-
-            <div class="neos-hide" id="protocol-modal">
-                <div class="neos-modal">
-                    <div class="neos-modal-header">
-                        <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                        <div class="neos-header">Warning</div>
-                    </div>
-                    <div class="neos-subheader">
-                        <p>
-                            Be aware that using <b>HTTP</b> for communication with your Matomo host
-                            <b>{settings.host}</b> will result in your super user's auth_token being transmitted as an
-                            unencrypted URL parameter!
-                            <br>
-                            <br>
-                        </p>
-                    </div>
-                    <div class="neos-modal-footer">
-                        <a href="#" class="neos-button" data-dismiss="modal">OK</a>
-                    </div>
-                </div>
-                <div class="neos-modal-backdrop neos-in"></div>
+                <h3>Tokens</h3>
+                <table class="neos-table">
+                    <tr>
+                        <th>Sitename</th>
+                        <th>Authentication Token</th>
+                    </tr>
+                    <f:for each="{tokens}" key="sitename" as="token">
+                        <tr>
+                            <td>{sitename}</td>
+                            <td>{token}</td>
+                        </tr>
+                    </f:for>
+                </table>
             </div>
 
             <div class="neos-control-group">
-                <strong>Token:</strong>
-                {settings.token_auth}
-            </div>
-        </div>
-
-        <div class="neos-span6 neos-pull-right">
-            <h2>Matomo Host Information</h2>
-            <br>
-            <div class="neos-control-group">
-                <strong>IP Address:</strong>
-                <f:if condition="{matomoHost.ip.value}">
-                    <f:then>
-                        {matomoHost.ip.value} <i class="icon icon-check-circle-o"></i>
-                    </f:then>
-                    <f:else>
-                        <i>Could not retrieve IP</i> <i class="icon icon-exclamation-triangle"></i>
-                    </f:else>
-                </f:if>
-            </div>
-
-            <div class="neos-control-group">
-                <strong>Version:</strong>
-                <f:if condition="{matomoHost.version.value}">
-                    <f:then>
-                        {matomoHost.version.value} <i class="icon icon-check-circle-o"></i>
-                    </f:then>
-                    <f:else>
-                        <i>Could not retrieve version</i> <i class="icon icon-exclamation-triangle"></i>
-                    </f:else>
-                </f:if>
-            </div>
-
-            <div class="neos-control-group">
-                <strong>Sitename:</strong>
-                <f:if condition="{matomoHost.site.0}">
-                    <f:then>
-                        {matomoHost.site.0.name} <i class="icon icon-check-circle-o"></i>
-                    </f:then>
-                    <f:else>
-                        <i>{matomoHost.site.message}</i> <i class="icon icon-exclamation-triangle"></i>
-                    </f:else>
-                </f:if>
+                <h3>Site mapping</h3>
+                <table class="neos-table">
+                    <tr>
+                        <th>Sitename</th>
+                        <th>Matomo Site ID</th>
+                        <th>Matomo Site Name</th>
+                    </tr>
+                    <f:for each="{sites}" key="sitename" as="site">
+                        <tr>
+                            <td>{sitename}</td>
+                            <td>{site.id}</td>
+                            <td>
+                                <f:if condition="{site.matomoName.0}">
+                                    <f:then>
+                                        {site.matomoName.0.name} <i class="icon icon-check-circle-o"></i>
+                                    </f:then>
+                                    <f:else>
+                                        <i>{site.matomoName.message}</i> <i class="icon icon-exclamation-triangle"></i>
+                                    </f:else>
+                                </f:if>
+                            </td>
+                        </tr>
+                    </f:for>
+                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This change makes it possible to optionally define
multiple sites in the configuration.

The tracking code and backend requests
will then use the setting depending on the
current sites name.

Resolves: #20 