### PR TITLE
Support Matomo installations in folder

### DIFF
--- a/Classes/Service/Reporting.php
+++ b/Classes/Service/Reporting.php
@@ -244,7 +244,8 @@ class Reporting extends AbstractServiceController
         }
 
         $apiCallUrl = new Uri($this->settings['protocol'] . '://' . $this->settings['host']);
-        $apiCallUrl->setPath('/index.php');
+        $installPath = empty($apiCallUrl->getPath()) ? '' : $apiCallUrl->getPath();
+        $apiCallUrl->setPath($installPath . '/index.php');
         $apiCallUrl->setQuery(http_build_query(array_merge([
             'module' => 'API',
             'format' => 'json',

--- a/Classes/Service/Reporting.php
+++ b/Classes/Service/Reporting.php
@@ -244,8 +244,7 @@ class Reporting extends AbstractServiceController
         }
 
         $apiCallUrl = new Uri($this->settings['protocol'] . '://' . $this->settings['host']);
-        $installPath = empty($apiCallUrl->getPath()) ? '' : $apiCallUrl->getPath();
-        $apiCallUrl->setPath($installPath . '/index.php');
+        $apiCallUrl->setPath($apiCallUrl->getPath() . '/index.php');
         $apiCallUrl->setQuery(http_build_query(array_merge([
             'module' => 'API',
             'format' => 'json',


### PR DESCRIPTION
`setPath` overwrites the path part of Matomo installations which are not located in the root directory of a website. E.g. `example.org/matomo/`.