### PR TITLE
Don't show unnecessary protocol warning

### DIFF
--- a/Resources/Private/Templates/Module/Matomo/Index.html
+++ b/Resources/Private/Templates/Module/Matomo/Index.html
@@ -19,9 +19,9 @@
                         <td>Protocol</td>
                         <td>
                             {settings.protocol}
-                            <f:if condition="{settings.protocol}!=https">
-                            <span data-toggle="modal" class="neos-inline neos-button neos-button-small"
-                                  href="#protocol-modal">?</span>
+                            <f:if condition="{settings.protocol} != 'https'">
+                                <span data-toggle="modal" class="neos-inline neos-button neos-button-small"
+                                      href="#protocol-modal">?</span>
                             </f:if>
 
                             <div class="neos-hide" id="protocol-modal">

--- a/Resources/Private/Templates/Module/Matomo/Index.html
+++ b/Resources/Private/Templates/Module/Matomo/Index.html
@@ -19,8 +19,10 @@
                         <td>Protocol</td>
                         <td>
                             {settings.protocol}
+                            <f:if condition="{settings.protocol}!=https">
                             <span data-toggle="modal" class="neos-inline neos-button neos-button-small"
                                   href="#protocol-modal">?</span>
+                            </f:if>
 
                             <div class="neos-hide" id="protocol-modal">
                                 <div class="neos-modal">


### PR DESCRIPTION
If you already use https the warning about http is obsolete.