### PR TITLE
FEATURE: Tag Manager support

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,6 +5,7 @@ Flowpack:
       protocol: https
       token_auth: ''
       idSite: ''
+      containerId: ''
       apiTimeout: 10
       cacheLifetimeByPeriod:
         year: 86400

--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,18 @@ See this example with one token but several sites:
             mysecondsite: 2
             mythirdsite: 2
 
+And the same when used with tag manager:
+
+    Flowpack:
+      Neos:
+        Matomo:
+          host: tracking.example.org
+          token_auth: 12345678910
+          containerId:
+            myfirstsite: 'abc'
+            mysecondsite: 'def'
+            mythirdsite: 'ghi'
+
 ## License
 
 Neos Matomo Package is released under the GPL v3 (or later) license.

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ This package integrates the `Matomo Open Analytics Platform` into Neos and is al
  + adds a Backend Module to your Neos instance which helps checking your configuration
  + adds a tab to the Property Inspector, which shows time, device, OS and browser related statistics collected by Matomo
  + adds a customizeable content element which allows visitors to opt-out of tracking in the frontend
+ + Matomo Tag Manger support
 
 Inspired by the packages [neos/neos-googleanalytics](https://github.com/neos/neos-googleanalytics) and [khuppenbauer/MapSeven.Piwik](https://github.com/khuppenbauer/MapSeven.Piwik).
 
@@ -45,9 +46,11 @@ releases of this package if possible.
 
 ## Installation
 
-Run the following command
+Run the following command in your site package
 
-    $ composer require flowpack/neos-matomo
+    composer require --no-update flowpack/neos-matomo
+    
+Then run `composer update` in your project root.
 
 ### Updating from `neos-piwik` to `neos-matomo`
 
@@ -93,6 +96,12 @@ You have to enter a valid auth token of a Matomo user who has the `view` permiss
 
 + **idSite**
 You have to enter the id of the site you configured in Matomo.
+You should not set this if you also have `containerId` set.
+
++ **containerId**
+You have to enter the id of the tag manager container you configured in Matomo.
+Here you can also use the longer ids generated for dev & staging environments.
+You should not set this if you also have `idSite` set.
 
 + **apiTimeout**
 You can change the default timeout of 10 seconds after which the backend will cancel requests to your
@@ -106,7 +115,8 @@ Matomo installation.
           host: 'tracking.example.org'
           protocol: 'https'
           token_auth: 'abcdefg1234567890'
-          idSite: 1
+          idSite: 1 # Only if containerId is not set                                          
+          containerId: 'abcdef' # Only if idSite is not set
           apiTimeout: 10 
           cacheLifetimeByPeriod:
             year: 86400

--- a/Resources/Private/Fusion/Prototypes/Override.Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Override.Page.fusion
@@ -1,0 +1,10 @@
+prototype(Neos.Neos:Page) {
+    matomoTrackingCode = Flowpack.Neos.Matomo:TrackingCode {
+        # Matomo suggests to include the tracking code directly before the closing <head> tag
+        @position = 'before closingHeadTag 100'
+    }
+    matomoTagManager = Flowpack.Neos.Matomo:TagManager {
+        # Matomo suggests to include the tracking code directly after the <head> tag
+        @position = 'after headTag 100'
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/TagManager.fusion
+++ b/Resources/Private/Fusion/Prototypes/TagManager.fusion
@@ -1,0 +1,26 @@
+prototype(Flowpack.Neos.Matomo:TagManager) < prototype(Neos.Fusion:Tag) {
+    @if.hasContainerId = ${this.containerId}
+
+    settings = ${Configuration.setting('Flowpack.Neos.Matomo')}
+    protocol = ${this.settings.protocol}
+    host = ${this.settings.host}
+    containerId = ${this.settings.containerId}
+
+    @context {
+        protocol = ${this.protocol}
+        host = ${this.host}
+        containerId = ${this.containerId}
+    }
+
+    tagName = 'script'
+    attributes {
+        type = 'text/javascript'
+    }
+    content = Neos.Fusion:Array {
+        mtm = 'var _mtm = _mtm || [];'
+        push = '_mtm.push({"mtm.startTime": (new Date().getTime()), "event": "mtm.Start"});'
+        createElement = 'var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0];'
+        element = ${'g.type="text/javascript"; g.async=true; g.defer=true; g.src="' + protocol + '://' + host + '/js/container_' + containerId + '.js"; s.parentNode.insertBefore(g,s);'}
+    }
+    @process.wrapInComment = ${'<!-- Matomo Tag Manager -->' + value + '<!-- End Matomo Tag Manager -->'}
+}

--- a/Resources/Private/Fusion/Prototypes/TagManager.fusion
+++ b/Resources/Private/Fusion/Prototypes/TagManager.fusion
@@ -5,6 +5,7 @@ prototype(Flowpack.Neos.Matomo:TagManager) < prototype(Neos.Fusion:Tag) {
     protocol = ${this.settings.protocol}
     host = ${this.settings.host}
     containerId = ${this.settings.containerId}
+    containerId.@process.containerId = ${Type.isArray(value) ? value[site.name] || Array.first(value) : value}
 
     @context {
         protocol = ${this.protocol}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,8 +1,1 @@
-include: 'Prototypes/*'
-
-prototype(Neos.Neos:Page) {
-  matomoTrackingCode = Flowpack.Neos.Matomo:TrackingCode {
-    # Matomo suggests to include the tracking code directly after the <body> tag
-    @position = 'after bodyTag 100'
-  }
-}
+include: **/*.fusion


### PR DESCRIPTION
Use it by setting `containerId` in the config.
Should not be used with idSite at the same time.