### PR TITLE
TASK: Add new Setting to target the right Tracker in Tracking Code

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,11 +1,12 @@
 Flowpack:
   Neos:
     Matomo:
-      host: ''
+      host: ""
       protocol: https
-      token_auth: ''
-      idSite: ''
-      containerId: ''
+      system: matomo
+      token_auth: ""
+      idSite: ""
+      containerId: ""
       apiTimeout: 10
       cacheLifetimeByPeriod:
         year: 86400
@@ -17,7 +18,7 @@ Neos:
       translation:
         autoInclude:
           Flowpack.Neos.Matomo:
-            - 'NodeTypes/*'
+            - "NodeTypes/*"
     modules:
       seo:
         label: SEO
@@ -26,12 +27,12 @@ Neos:
           matomo:
             label: Matomo
             controller: \Flowpack\Neos\Matomo\Controller\Module\MatomoController
-            description: 'Configure Matomo for your Domains'
+            description: "Configure Matomo for your Domains"
             icon: icon-bar-chart
             actions:
               index:
-                label: 'Configure Matomo'
-                title: 'Configure Matomo'
+                label: "Configure Matomo"
+                title: "Configure Matomo"
     fusion:
       autoInclude:
         Flowpack.Neos.Matomo: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,12 +1,12 @@
 Flowpack:
   Neos:
     Matomo:
-      host: ""
+      host: ''
       protocol: https
       system: matomo
-      token_auth: ""
-      idSite: ""
-      containerId: ""
+      token_auth: ''
+      idSite: ''
+      containerId: ''
       apiTimeout: 10
       cacheLifetimeByPeriod:
         year: 86400
@@ -18,7 +18,7 @@ Neos:
       translation:
         autoInclude:
           Flowpack.Neos.Matomo:
-            - "NodeTypes/*"
+            - 'NodeTypes/*'
     modules:
       seo:
         label: SEO
@@ -27,12 +27,12 @@ Neos:
           matomo:
             label: Matomo
             controller: \Flowpack\Neos\Matomo\Controller\Module\MatomoController
-            description: "Configure Matomo for your Domains"
+            description: 'Configure Matomo for your Domains'
             icon: icon-bar-chart
             actions:
               index:
-                label: "Configure Matomo"
-                title: "Configure Matomo"
+                label: 'Configure Matomo'
+                title: 'Configure Matomo'
     fusion:
       autoInclude:
         Flowpack.Neos.Matomo: true

--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,7 @@ Here you can also use the longer ids generated for dev & staging environments.
 
 + **system**
 You can change the System you're using so it will target the right Tracking Code.
+Defaults to `matomo`, if needed, set it to `piwik`
 
 + **apiTimeout**
 You can change the default timeout of 10 seconds after which the backend will cancel requests to your
@@ -119,7 +120,7 @@ Matomo installation.
           token_auth: 'abcdefg1234567890'
           idSite: 1                                           
           containerId: 'abcdef' # Optional
-          system: 'matomo' # Optional
+          system: 'matomo' # Optional, "matomo" or "piwik"
           apiTimeout: 10 
           cacheLifetimeByPeriod:
             year: 86400

--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,9 @@ This is also needed when using Matomo Tag Manager to allow showing statistics in
 You have to enter the id of the tag manager container you configured in Matomo.
 Here you can also use the longer ids generated for dev & staging environments.
 
++ **system**
+You can change the System you're using so it will target the right Tracking Code.
+
 + **apiTimeout**
 You can change the default timeout of 10 seconds after which the backend will cancel requests to your
 Matomo installation.
@@ -116,6 +119,7 @@ Matomo installation.
           token_auth: 'abcdefg1234567890'
           idSite: 1                                           
           containerId: 'abcdef' # Optional
+          system: 'matomo' # Optional
           apiTimeout: 10 
           cacheLifetimeByPeriod:
             year: 86400

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
@@ -6,6 +6,7 @@ prototype(Flowpack.Neos.Matomo:TrackingCode) < prototype(Neos.Fusion:Template) {
     settings = ${Configuration.setting('Flowpack.Neos.Matomo')}
     protocol = ${this.settings.protocol}
     host = ${this.settings.host}
+    system = ${this.settings.system}
     idSite = ${this.settings.idSite}
     idSite.@process.multiSite = ${Type.isArray(value) ? value[site.name] || Array.first(value) : value}
     containerId = ${this.settings.containerId}

--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -3,11 +3,11 @@
   var _paq = _paq || [];
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
-  (function () {
+  (function() {
     var u="{protocol}://{host}/";
     _paq.push(['setTrackerUrl', u+'{system}.php']);
     _paq.push(['setSiteId', {idSite}]);
-    var d=document, gd.createElement('script'), s=d.getElementsByTagName('script')[0];
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'{system}.js'; s.parentNode.insertBefore(g,s);
   })();
 

--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -4,14 +4,13 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function () {
-    var u = '{protocol}://{host}/';
+    var u="{protocol}://{host}/";
     _paq.push(['setTrackerUrl', u+'{system}.php']);
     _paq.push(['setSiteId', {idSite}]);
-    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    var d=document, gd.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'{system}.js'; s.parentNode.insertBefore(g,s);
   })();
 
 </script>
-<noscript><p><img src="{protocol}://{host}/{system}.php?idsite={idSite}" style="border:0;" alt="" /></p
-></noscript>
+<noscript><p><img src="{protocol}://{host}/{system}.php?idsite={idSite}" style="border:0;" alt="" /></p></noscript>
 <!-- End Matomo Code -->

--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -1,17 +1,28 @@
 <!-- Matomo -->
 <script type="text/javascript">
   var _paq = _paq || [];
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="{protocol}://{host}/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', {idSite}]);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  _paq.push(["trackPageView"]);
+  _paq.push(["enableLinkTracking"]);
+  (function () {
+    var u = "{protocol}://{host}/";
+    _paq.push(["setTrackerUrl", u + "{system}.php"]);
+    _paq.push(["setSiteId", { idSite }]);
+    var d = document,
+      g = d.createElement("script"),
+      s = d.getElementsByTagName("script")[0];
+    g.type = "text/javascript";
+    g.async = true;
+    g.defer = true;
+    g.src = u + "{system}.js";
+    s.parentNode.insertBefore(g, s);
   })();
-
 </script>
-<noscript><p><img src="{protocol}://{host}/piwik.php?idsite={idSite}" style="border:0;" alt="" /></p></noscript>
+<noscript
+  ><p>
+    <img
+      src="{protocol}://{host}/{system}.php?idsite={idSite}"
+      style="border:0;"
+      alt=""
+    /></p
+></noscript>
 <!-- End Matomo Code -->
-

--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -1,28 +1,17 @@
 <!-- Matomo -->
 <script type="text/javascript">
   var _paq = _paq || [];
-  _paq.push(["trackPageView"]);
-  _paq.push(["enableLinkTracking"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
   (function () {
-    var u = "{protocol}://{host}/";
-    _paq.push(["setTrackerUrl", u + "{system}.php"]);
-    _paq.push(["setSiteId", { idSite }]);
-    var d = document,
-      g = d.createElement("script"),
-      s = d.getElementsByTagName("script")[0];
-    g.type = "text/javascript";
-    g.async = true;
-    g.defer = true;
-    g.src = u + "{system}.js";
-    s.parentNode.insertBefore(g, s);
+    var u = '{protocol}://{host}/';
+    _paq.push(['setTrackerUrl', u+'{system}.php']);
+    _paq.push(['setSiteId', {idSite}]);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'{system}.js'; s.parentNode.insertBefore(g,s);
   })();
+
 </script>
-<noscript
-  ><p>
-    <img
-      src="{protocol}://{host}/{system}.php?idsite={idSite}"
-      style="border:0;"
-      alt=""
-    /></p
+<noscript><p><img src="{protocol}://{host}/{system}.php?idsite={idSite}" style="border:0;" alt="" /></p
 ></noscript>
 <!-- End Matomo Code -->


### PR DESCRIPTION
This adds a new Setting called `system` which is used to target the right Endpoints in the Matomo / Piwik Instance.

The problem is that Matomo uses "new" Endpoints which are `matomo.php` and `matomo.js` in the Tracking Code while Piwik uses `piwik.php` and `piwik.js`. Thus the Package won't work when using a new Matomo Instance.

Excerpt from the "Tracking Code"-Page in Matomo.
![Matomo_System_TrackingCode](https://user-images.githubusercontent.com/43070365/170706401-73742136-76bd-4a80-8eb0-3753d0193437.png)

