### PR TITLE
FEATURE: Add privacy option to uses matomo's privacy/consent management mechanism

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,6 +11,10 @@ Flowpack:
       cacheLifetimeByPeriod:
         year: 86400
         day: 3600
+      privacyManagement:
+        disableCookies: false # this disables all cookies. See https://matomo.org/faq/general/faq_157/
+        requireTrackingConsent: false # requires user's tracking consent before making tracking calls to matomo. See https://developer.matomo.org/guides/tracking-consent
+        requireCookieConsent: false # requires user's consent before setting cookies. See https://developer.matomo.org/guides/tracking-consent
 
 Neos:
   Neos:

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.fusion
@@ -11,6 +11,7 @@ prototype(Flowpack.Neos.Matomo:TrackingCode) < prototype(Neos.Fusion:Template) {
     idSite.@process.multiSite = ${Type.isArray(value) ? value[site.name] || Array.first(value) : value}
     containerId = ${this.settings.containerId}
     containerId.@process.containerId = ${Type.isArray(value) ? value[site.name] || Array.first(value) : value}
+    privacyManagement = ${this.settings.privacyManagement}
 
     // Show tracking code only in live workspace and if all necessary parameters are set
     @if {

--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -1,6 +1,15 @@
 <!-- Matomo -->
 <script type="text/javascript">
   var _paq = _paq || [];
+  <f:if condition="{privacyManagement.disableCookies}">
+    _paq.push(['disableCookies']);
+  </f:if>
+  <f:if condition="{privacyManagement.requireTrackingConsent}">
+    _paq.push(['requireConsent']);
+  </f:if>
+  <f:if condition="{privacyManagement.requireCookieConsent}">
+    _paq.push(['requireCookieConsent']);
+  </f:if>
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
This PR adds YAML configuration setting properties, which allow the use of Matomo's GDPR/ePrivacy features.

See
- https://developer.matomo.org/guides/tracking-consent and
- https://matomo.org/faq/general/faq_157/